### PR TITLE
Refactor backup script into modular package

### DIFF
--- a/usb_backup/backup.py
+++ b/usb_backup/backup.py
@@ -1,0 +1,151 @@
+import os
+import shutil
+import subprocess
+import time
+from threading import Thread
+
+from .log_utils import log
+from .led import blink_leds, LoadingAnimation
+from .utils import update_status
+from .button import delete_files_from_source
+
+
+def mount_device(device, mountpoint):
+    os.makedirs(mountpoint, exist_ok=True)
+    result = subprocess.run(['sudo', 'mount', device, mountpoint])
+    return result.returncode == 0
+
+
+def unmount_device(mountpoint):
+    subprocess.run(['sudo', 'umount', mountpoint])
+
+
+def is_device_connected(device_path):
+    return os.path.exists(device_path)
+
+
+def finde_quelle_und_ziel():
+    while True:
+        output = subprocess.check_output(['lsblk', '-P', '-o', 'NAME,RM,LABEL,TYPE']).decode()
+        lines = output.strip().splitlines()
+        quelle = None
+        ziel = None
+        for zeile in lines:
+            entry = dict(item.split('=') for item in zeile.strip().split())
+            name = entry['NAME'].strip('"')
+            typ = entry['TYPE'].strip('"')
+            rm = entry['RM'].strip('"')
+            label = entry.get('LABEL', '').strip('"')
+            if typ != 'part':
+                continue
+            device = f"/dev/{name}"
+            if label == 'BACKUP':
+                ziel = device
+            elif rm == '1':
+                quelle = device
+        if not ziel:
+            log('⚠️ Backup-Festplatte nicht gefunden. Bitte anschließen.')
+            blink_leds((255, 255, 0), 1)
+            update_status(state='kein backup ziel', errors=['Backup-Festplatte nicht gefunden'])
+            time.sleep(2)
+            continue
+        if quelle and ziel and quelle != ziel:
+            log(f"📥 Quelle: {quelle}")
+            log(f"📤 Ziel  : {ziel}")
+            update_status(state='bereit', errors=[])
+            return quelle, ziel
+        blink_leds((0, 0, 255), 1)
+        log('🔵 Bitte USB-Stick einstecken...')
+        update_status(state='warte auf stick', errors=[])
+        time.sleep(2)
+
+
+def kopiere_daten(quelle, ziel, counter):
+    quelle_mount = '/mnt/QUELLE'
+    ziel_mount = '/mnt/BACKUP'
+
+    if not mount_device(quelle, quelle_mount):
+        log('❌ Fehler beim Mounten der Quelle!')
+        blink_leds((255, 0, 0), 10)
+        update_status(state='fehler mount quelle', errors=['Fehler beim Mounten der Quelle'])
+        return
+
+    if not mount_device(ziel, ziel_mount):
+        log('❌ Fehler beim Mounten des Ziels!')
+        blink_leds((255, 0, 0), 10)
+        unmount_device(quelle_mount)
+        update_status(state='fehler mount ziel', errors=['Fehler beim Mounten des Ziels'])
+        return
+
+    total_size = 0
+    for root, _, files in os.walk(quelle_mount):
+        for file in files:
+            try:
+                total_size += os.path.getsize(os.path.join(root, file))
+            except Exception:
+                continue
+    if total_size == 0:
+        log('🟦 Keine Dateien zum Kopieren gefunden!')
+        blink_leds((0, 0, 255), 10)
+        unmount_device(quelle_mount)
+        unmount_device(ziel_mount)
+        update_status(state='keine dateien', errors=['Keine Dateien zum Kopieren gefunden'])
+        return
+
+    ziel_ordner = os.path.join(ziel_mount, f"USB_Stick_{counter}")
+    os.makedirs(ziel_ordner, exist_ok=True)
+    copied_size = 0
+
+    log('⚡️ Starte Kopiervorgang...')
+    update_status(state='kopiere', progress=0, errors=[])
+
+    progress = 0
+    anim = LoadingAnimation(lambda: progress)
+    anim.start()
+
+    for root, _, files in os.walk(quelle_mount):
+        for file in files:
+            src_path = os.path.join(root, file)
+            rel_path = os.path.relpath(src_path, quelle_mount)
+            dst_path = os.path.join(ziel_ordner, rel_path)
+            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+            try:
+                shutil.copy2(src_path, dst_path)
+                os.remove(src_path)
+            except Exception as e:
+                log(f'❌ Fehler beim Kopieren von {src_path}: {e}')
+                anim.running = False
+                anim.join()
+                blink_leds((255, 0, 0), 10)
+                unmount_device(quelle_mount)
+                unmount_device(ziel_mount)
+                update_status(state='fehler kopieren', errors=[f'Fehler beim Kopieren: {e}'])
+                return
+            copied_size += os.path.getsize(dst_path)
+            progress = min((copied_size / total_size) * 100, 100)
+            log(f'✅ Kopiert: {rel_path} ({progress:.1f}%)')
+            update_status(state='kopiere', progress=progress, errors=[])
+
+    anim.running = False
+    anim.join()
+    log('✅ Backup erfolgreich abgeschlossen!')
+    update_status(state='erfolgreich', progress=100, errors=[])
+
+    while is_device_connected(quelle):
+        blink_leds((0, 255, 0), 1)
+        time.sleep(1)
+    blink_leds((0, 255, 0), 10)
+    unmount_device(quelle_mount)
+    unmount_device(ziel_mount)
+
+
+def backup_loop(counter_start=1):
+    counter = counter_start
+    update_status(state='starte', errors=[])
+    while True:
+        quelle, ziel = finde_quelle_und_ziel()
+        kopiere_daten(quelle, ziel, counter)
+        counter += 1
+        log('🟦 Warten auf nächsten Stick...')
+        update_status(state='warte', errors=[])
+        time.sleep(3)

--- a/usb_backup/button.py
+++ b/usb_backup/button.py
@@ -1,0 +1,68 @@
+import os
+import json
+import time
+from threading import Thread
+import RPi.GPIO as GPIO
+
+from .config import BUTTON_PIN, STATUS_LED_PIN, DELETE_STATE_FILE
+from .log_utils import log
+
+delete_enabled = True
+
+
+def save_delete_state():
+    with open(DELETE_STATE_FILE, 'w') as f:
+        json.dump({"delete_enabled": delete_enabled}, f)
+
+
+def load_delete_state():
+    global delete_enabled
+    if os.path.exists(DELETE_STATE_FILE):
+        try:
+            with open(DELETE_STATE_FILE) as f:
+                state = json.load(f)
+                delete_enabled = state.get("delete_enabled", True)
+        except Exception:
+            delete_enabled = True
+
+
+def update_status_led():
+    GPIO.output(STATUS_LED_PIN, GPIO.HIGH if delete_enabled else GPIO.LOW)
+
+
+def monitor_button():
+    global delete_enabled
+    last_state = False
+    while True:
+        input_state = GPIO.input(BUTTON_PIN)
+        if input_state and not last_state:
+            delete_enabled = not delete_enabled
+            update_status_led()
+            save_delete_state()
+            log(f"🔘 Taster gedrueckt – Loeschmodus: {'AN' if delete_enabled else 'AUS'}")
+            time.sleep(0.3)
+        last_state = input_state
+        time.sleep(0.05)
+
+
+def setup():
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setwarnings(False)
+    GPIO.setup(BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+    GPIO.setup(STATUS_LED_PIN, GPIO.OUT)
+    load_delete_state()
+    update_status_led()
+    Thread(target=monitor_button, daemon=True).start()
+
+
+def delete_files_from_source(source_path):
+    if not delete_enabled:
+        log("[INFO] Loeschmodus deaktiviert – Dateien bleiben erhalten.")
+        return
+    for root, _, files in os.walk(source_path):
+        for file in files:
+            try:
+                os.remove(os.path.join(root, file))
+                log(f"[GELÖSCHT] {file}")
+            except Exception as e:
+                log(f"[FEHLER] Datei nicht geloescht: {file} – {e}")

--- a/usb_backup/config.py
+++ b/usb_backup/config.py
@@ -1,0 +1,10 @@
+PIXEL_COUNT = 10
+PIN = 18
+BRIGHTNESS_FILE = '/tmp/usb_led_brightness.txt'
+STATUS_FILE = '/tmp/usb_backup_status.json'
+LOG_FILE = '/tmp/usb_backup.log'
+LED_ENABLED = True
+
+BUTTON_PIN = 27
+STATUS_LED_PIN = 24
+DELETE_STATE_FILE = '/tmp/delete_mode.json'

--- a/usb_backup/led.py
+++ b/usb_backup/led.py
@@ -1,0 +1,90 @@
+import os
+import time
+import colorsys
+import board
+import neopixel
+from threading import Thread
+
+from .config import PIXEL_COUNT, PIN, BRIGHTNESS_FILE
+from .log_utils import log
+
+pixels = neopixel.NeoPixel(board.D18, PIXEL_COUNT, auto_write=False, brightness=0.5)
+LED_ENABLED = True
+
+
+def rainbow_color(pos, total):
+    hue = pos / total
+    r, g, b = [int(c * 255) for c in colorsys.hsv_to_rgb(hue, 1, 1)]
+    return (r, g, b)
+
+
+def set_led_brightness(value):
+    try:
+        value = float(value)
+        value = max(0, min(value, 1))
+        pixels.brightness = value
+        with open(BRIGHTNESS_FILE, 'w') as f:
+            f.write(str(value))
+    except Exception as e:
+        log(f"Fehler LED-Helligkeit: {e}")
+
+
+def get_led_brightness():
+    try:
+        if os.path.exists(BRIGHTNESS_FILE):
+            with open(BRIGHTNESS_FILE) as f:
+                return float(f.read())
+    except Exception:
+        pass
+    return 0.5
+
+
+def set_led_enabled(onoff: bool):
+    global LED_ENABLED
+    LED_ENABLED = bool(onoff)
+    if not LED_ENABLED:
+        pixels.fill((0, 0, 0))
+        pixels.show()
+
+
+def blink_leds(color, times):
+    if not LED_ENABLED:
+        return
+    for _ in range(times):
+        pixels.fill(color)
+        pixels.show()
+        time.sleep(0.4)
+        pixels.fill((0, 0, 0))
+        pixels.show()
+        time.sleep(0.4)
+
+
+class LoadingAnimation(Thread):
+    def __init__(self, progress_func):
+        super().__init__()
+        self.progress_func = progress_func
+        self.running = True
+
+    def run(self):
+        total_leds = PIXEL_COUNT
+        fixed_led_index = total_leds - 1
+        animation_index = 0
+        while self.running and LED_ENABLED:
+            progress_percent = self.progress_func()
+            leds_done = int(progress_percent / 10)
+            pixels.fill((0, 0, 0))
+            pixels[fixed_led_index] = rainbow_color(fixed_led_index, total_leds)
+            for i in range(leds_done):
+                led_index = fixed_led_index - i
+                pixels[led_index] = rainbow_color(led_index, total_leds)
+            if progress_percent < 100 and leds_done < fixed_led_index:
+                animation_range = fixed_led_index - leds_done
+                animation_pos = animation_index % (animation_range + 1)
+                led_index = leds_done + animation_pos
+                if led_index < fixed_led_index:
+                    pixels[led_index] = rainbow_color(led_index, total_leds)
+                animation_index += 1
+            pixels.show()
+            time.sleep(0.2)
+        pixels.fill((0, 0, 0))
+        pixels.show()

--- a/usb_backup/log_utils.py
+++ b/usb_backup/log_utils.py
@@ -1,0 +1,7 @@
+import time
+from .config import LOG_FILE
+
+def log(msg):
+    print(msg)
+    with open(LOG_FILE, 'a', encoding='utf-8') as f:
+        f.write(f"[{time.strftime('%H:%M:%S')}] {msg}\n")

--- a/usb_backup/main.py
+++ b/usb_backup/main.py
@@ -1,0 +1,17 @@
+from threading import Thread
+
+from .led import set_led_brightness, get_led_brightness
+from .button import setup as setup_button
+from .backup import backup_loop
+from .webapp import app
+
+
+def main():
+    set_led_brightness(get_led_brightness())
+    setup_button()
+    Thread(target=backup_loop, daemon=True).start()
+    app.run(host='0.0.0.0', port=8000, debug=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/usb_backup/utils.py
+++ b/usb_backup/utils.py
@@ -1,0 +1,70 @@
+import os
+import json
+import subprocess
+import time
+from .config import STATUS_FILE
+from .log_utils import log
+
+
+def get_disk_info():
+    try:
+        output = subprocess.check_output(['lsblk', '-P', '-o', 'NAME,LABEL,MOUNTPOINT,TYPE']).decode()
+        for line in output.strip().splitlines():
+            entry = dict(item.split('=') for item in line.strip().split())
+            label = entry.get('LABEL', '').strip('"')
+            name = entry.get('NAME', '').strip('"')
+            mountpoint = entry.get('MOUNTPOINT', '').strip('"')
+            typ = entry.get('TYPE', '').strip('"')
+            if label == 'BACKUP' and typ == 'part':
+                device = f"/dev/{name}"
+                if not mountpoint:
+                    mountpoint = '/mnt/BACKUP'
+                    os.makedirs(mountpoint, exist_ok=True)
+                    res = subprocess.run(['sudo', 'mount', device, mountpoint], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    if res.returncode != 0:
+                        return {
+                            'total': 'Nicht gemountet',
+                            'used': '-',
+                            'free': '-',
+                            'total_raw': 0,
+                            'used_raw': 0,
+                            'free_raw': 0
+                        }
+                st = os.statvfs(mountpoint)
+                total = st.f_blocks * st.f_frsize
+                free = st.f_bavail * st.f_frsize
+                used = total - free
+                total_gb = round(total / (1024 ** 3), 1)
+                used_gb = round(used / (1024 ** 3), 1)
+                free_gb = round(free / (1024 ** 3), 1)
+                return {
+                    'total': f'{total_gb} GB',
+                    'used': f'{used_gb} GB',
+                    'free': f'{free_gb} GB',
+                    'total_raw': int(total // (1024 ** 2)),
+                    'used_raw': int(used // (1024 ** 2)),
+                    'free_raw': int(free // (1024 ** 2))
+                }
+    except Exception as e:
+        log(f'Fehler beim Lesen der Festplatteninfos: {e}')
+    return {
+        'total': 'Nicht verbunden',
+        'used': 'Nicht verbunden',
+        'free': 'Nicht verbunden',
+        'total_raw': 0,
+        'used_raw': 0,
+        'free_raw': 0
+    }
+
+
+def update_status(progress=0, state='warten', errors=None):
+    if errors is None:
+        errors = []
+    status = {
+        'progress': progress,
+        'state': state,
+        'errors': errors,
+        'disk': get_disk_info()
+    }
+    with open(STATUS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(status, f)

--- a/usb_backup/webapp.py
+++ b/usb_backup/webapp.py
@@ -1,0 +1,137 @@
+import os
+import subprocess
+import json
+from flask import Flask, jsonify, request, send_from_directory
+from .config import STATUS_FILE, LOG_FILE
+from .led import set_led_enabled, set_led_brightness, LED_ENABLED, get_led_brightness
+from .utils import update_status, get_disk_info
+
+app = Flask(__name__, static_folder='web')
+
+
+@app.route('/')
+def index():
+    return send_from_directory('web', 'index.html')
+
+
+@app.route('/api/status')
+def api_status():
+    if not os.path.exists(STATUS_FILE):
+        update_status(state='unbekannt')
+    with open(STATUS_FILE, encoding='utf-8') as f:
+        return jsonify(json.load(f))
+
+
+@app.route('/api/log')
+def api_log():
+    if os.path.exists(LOG_FILE):
+        with open(LOG_FILE, encoding='utf-8') as f:
+            return '<pre>' + f.read() + '</pre>'
+    return '<pre>Keine Logs vorhanden.</pre>'
+
+
+@app.route('/api/led', methods=['GET', 'POST'])
+def api_led():
+    if request.method == 'POST':
+        data = request.json or {}
+        if 'enabled' in data:
+            set_led_enabled(data['enabled'])
+        if 'brightness' in data:
+            set_led_brightness(data['brightness'])
+        return jsonify({'ok': True})
+    else:
+        return jsonify({'enabled': LED_ENABLED, 'brightness': get_led_brightness()})
+
+@app.route('/web/<path:path>')
+def send_web_static(path):
+    return send_from_directory('web', path)
+
+@app.route('/settings')
+def settings():
+    return send_from_directory('web', 'settings.html')
+
+@app.route('/log')
+def log_html():
+    return send_from_directory('web', 'log.html')
+
+@app.route('/api/list_drives')
+def api_list_drives():
+    output = subprocess.check_output(['lsblk', '-P', '-o', 'NAME,RM,SIZE,LABEL,TYPE']).decode()
+    drives = []
+    for line in output.strip().splitlines():
+        entry = dict(item.split('=') for item in line.strip().split())
+        name = entry['NAME'].strip('"')
+        if entry['TYPE'].strip('"') == 'part' and not name.startswith('mmcblk') and not name.startswith('loop') and not name.startswith('nvme'):
+            drives.append({
+                'name': name,
+                'device': '/dev/' + name,
+                'removable': entry['RM'].strip('"'),
+                'size': entry['SIZE'].strip('"'),
+                'label': entry.get('LABEL', '').strip('"')
+            })
+    return jsonify(drives)
+
+@app.route('/api/format_drive', methods=['POST'])
+def api_format_drive():
+    data = request.get_json(force=True)
+    device = data.get('device', '')
+    label = data.get('label', 'BACKUP')
+    if not device or not device.startswith('/dev/'):
+        return jsonify({'ok': False, 'msg': 'Ungültiges Gerät!'})
+    try:
+        subprocess.run(['sudo', 'umount', device], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        res = subprocess.run(['sudo', 'mkfs.exfat', '-n', label, device], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if res.returncode == 0:
+            return jsonify({'ok': True, 'msg': 'Laufwerk erfolgreich formatiert und gelabelt.'})
+        return jsonify({'ok': False, 'msg': res.stderr.decode()})
+    except Exception as e:
+        return jsonify({'ok': False, 'msg': str(e)})
+
+@app.route('/api/mount_drive', methods=['POST'])
+def api_mount_drive():
+    data = request.get_json(force=True)
+    device = data.get('device', '')
+    mountpoint = data.get('mountpoint', '/mnt/BACKUP')
+    if not device or not device.startswith('/dev/'):
+        return jsonify({'ok': False, 'msg': 'Ungültiges Gerät!'})
+    try:
+        os.makedirs(mountpoint, exist_ok=True)
+        output = subprocess.check_output(['mount']).decode()
+        if mountpoint in output:
+            return jsonify({'ok': True, 'msg': 'Bereits gemountet.'})
+        res = subprocess.run(['sudo', 'mount', device, mountpoint], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if res.returncode == 0:
+            return jsonify({'ok': True, 'msg': 'Laufwerk erfolgreich gemountet.'})
+        return jsonify({'ok': False, 'msg': res.stderr.decode()})
+    except Exception as e:
+        return jsonify({'ok': False, 'msg': str(e)})
+
+@app.route('/api/unmount_drive', methods=['POST'])
+def api_unmount_drive():
+    data = request.get_json(force=True)
+    device = data.get('device', '')
+    if not device or not device.startswith('/dev/'):
+        return jsonify({'ok': False, 'msg': 'Ungültiges Gerät!'})
+    try:
+        res = subprocess.run(['sudo', 'umount', device], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if res.returncode == 0:
+            return jsonify({'ok': True, 'msg': 'Laufwerk erfolgreich ausgehängt.'})
+        return jsonify({'ok': False, 'msg': res.stderr.decode()})
+    except Exception as e:
+        return jsonify({'ok': False, 'msg': str(e)})
+
+@app.route('/api/set_label_drive', methods=['POST'])
+def api_set_label_drive():
+    data = request.get_json(force=True)
+    device = data.get('device', '')
+    label = data.get('label', 'BACKUP')
+    if not device or not device.startswith('/dev/'):
+        return jsonify({'ok': False, 'msg': 'Ungültiges Gerät!'})
+    try:
+        subprocess.run(['sudo', 'umount', device], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        res = subprocess.run(['sudo', 'exfatlabel', device, label], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if res.returncode == 0:
+            return jsonify({'ok': True, 'msg': f"Laufwerk-Label erfolgreich auf '{label}' gesetzt."})
+        return jsonify({'ok': False, 'msg': res.stderr.decode()})
+    except Exception as e:
+        return jsonify({'ok': False, 'msg': str(e)})


### PR DESCRIPTION
## Summary
- break up large backup script into a reusable `usb_backup` package
- split LED, button, backup logic and web server into modules
- add a simple entry point in `usb_backup/main.py`

## Testing
- `python -m py_compile usb_backup/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688d35bc34c4832890e763eb064fa566